### PR TITLE
Add GPU supoprt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,29 @@
 from distutils.core import setup
 from setuptools import find_packages
+from subprocess import Popen
+from subprocess import PIPE
+
+
+def has_gpu():
+    try:
+        p = Popen(["nvidia-smi"], stdout=PIPE)
+        stdout, stderror = p.communicate()
+        return True
+
+    except Exception:
+        return False
+
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+
+install_requires = ["numpy"]
+if has_gpu():
+    install_requires.append("tensorflow-gpu>=1.6")
+else:
+    install_requires.append("tensorflow>=1.6")
+
 
 setup(
     name="tf_metrics",
@@ -17,8 +38,4 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ),
-    install_requires=[
-        "numpy",
-        "tensorflow>=1.6"
-    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,5 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ),
+    install_requires=install_requires
 )


### PR DESCRIPTION
Currently, tf_metrics install tensorflow CPU as the dependency.
I think it would be better that this module can be used in GPU enable environment.
So I edited `setup.py` to be check whether GPU is enable and install tensorflow according to it.

(thank for sharing awesome NER tool!! tf_ner and tf_metrics is very useful for me!!)