### PR TITLE
Explicitly specify the encoding while reading the readme file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ def has_gpu():
         return False
 
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
+with open("README.md", "rb") as fh:
+    long_description = fh.read().decode("utf-8")
 
 
 install_requires = ["numpy"]


### PR DESCRIPTION
Since the readme file contains a Unicode character, on some systems such as docker container when the terminal encoding is not proper, the setup fails with the following error:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 300: ordinal not in range(128)
```

The error is generated while reading the readme file in setup.py

This pull request will resolve this issue. The proposed solution is tested for Python 2.7 and Python 3.5.